### PR TITLE
Fix modal memory leak by cleaning up keydown listener

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -184,12 +184,15 @@ document.addEventListener('DOMContentLoaded', () => {
 
     document.body.appendChild(modal);
 
-    const escHandler = (e) => e.key === 'Escape' && close();
-
     const close = () => {
       document.removeEventListener('keydown', escHandler);
       modal.remove();
     };
+
+    const escHandler = (e) => {
+       if (e.key === 'Escape') close();
+    };
+
 
     modal.querySelector('.close-modal').onclick = close;
     modal.querySelector('.stream-detail-overlay').onclick = close;


### PR DESCRIPTION
Fixes #37

- Ensures keydown event listener is removed when modal closes
- Prevents multiple ESC handlers from stacking up
- Tested by opening/closing modal multiple times and pressing Escape
