### PR TITLE
Add push notification support in service worker

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -87,3 +87,39 @@ self.addEventListener("message", (event) => {
         self.skipWaiting();
     }
 });
+
+// Push notification handler
+self.addEventListener("push", (event) => {
+    let data = {};
+
+    if (event.data) {
+        try {
+            data = event.data.json();
+        } catch (e) {
+            data = { body: event.data.text() };
+        }
+    }
+
+    const title = data.title || "DevStreamer is Live!";
+    const options = {
+        body: data.body || "Your favorite DevStreamer just went live.",
+        icon: "/favicon.ico",
+        badge: "/favicon.ico",
+        data: {
+            url: data.url || "/"
+        }
+    };
+
+    event.waitUntil(
+        self.registration.showNotification(title, options)
+    );
+});
+
+// Notification click handler
+self.addEventListener("notificationclick", (event) => {
+    event.notification.close();
+
+    event.waitUntil(
+        clients.openWindow(event.notification.data.url)
+    );
+});


### PR DESCRIPTION
Fixes #38
This PR adds push notification handling to the service worker.

- Handles push events and displays notifications
- Handles notificationclick to open the app URL

