### PR TITLE
Fix: exclude API routes from service worker cache

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -50,6 +50,14 @@ self.addEventListener("activate", (event) => {
 
 // Fetch event handler with cache-first strategy
 self.addEventListener("fetch", (event) => {
+    if (!event.request.url.startsWith("http")) return;
+    const url = new URL(event.request.url);
+
+    // Do not cache API requests (like/ api/streams)
+    if (url.pathname.startsWith("/api/")) {
+        return;
+    }
+
     event.respondWith(
         caches.match(event.request).then((response) => {
             if (response) {
@@ -67,11 +75,11 @@ self.addEventListener("fetch", (event) => {
                 );
                 return response;
             }
-            
+
             // Handle non-cached requests
             return fetch(event.request).catch(error => {
                 console.error("Network request failed:", error);
-                
+
                 // Serve offline fallback for navigation requests
                 if (event.request.mode === 'navigate') {
                     return caches.match('/offline.html');


### PR DESCRIPTION
Fixes #8 

### What changed
Updated the service worker fetch handler to exclude API routes from the cache-first strategy.

### Why
The current cache-first approach can cache dynamic endpoints like /api/streams, which may cause users to see stale or outdated data. API responses should always be fetched from the network to ensure freshness.

### How
- Added a check to bypass caching for requests with /api/ paths
- Added a safety guard to ignore non HTTP(S) requests
- Kept existing cache first behavior for static assets unchanged

### Result
- Static assets remain fast and cached
- Live/API data is always fresh and up to date
