### PR TITLE
Add 404 not found route handler

### DIFF
--- a/server.js
+++ b/server.js
@@ -85,6 +85,13 @@ app.get('/api/streams', (req, res) => {
     });
 });
 
+// 404 Not Found handler (must be after all routes)
+app.use((req, res) => {
+    res.status(404).json({
+        error: "Route not found"
+    });
+});
+
 app.listen(PORT, () => {
     console.log(`\n✅ Server successfully started!`);
     console.log(`🏠 Home: http://localhost:${PORT}`);


### PR DESCRIPTION
Fixes #48 

Adds a fallback 404 handler to return a proper JSON response for unmatched routes.
This ensures unknown routes return a clear 404 response.