### PR TITLE
Feat: Add /health endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -95,6 +95,14 @@ app.get('/api/streams', (req, res) => {
   });
 });
 
+app.get('/health', (req,res)=>{
+  res.status(200).json({
+    status: 'OK',
+    message: 'Server is healthy',
+    timestamp: new Date().toISOString()
+  });
+});
+
 // 404 Not Found handler (must be after all routes)
 app.use((req, res) => {
     res.status(404).json({


### PR DESCRIPTION
Hi! As requested, I have added the /health endpoint to server.js.

Changes:

Implemented GET /health which returns 200 OK and a timestamp.

Fix: Renamed .env.example: to .env.example.

Reason for the file rename: I am working on Windows, and the colon (:) in the filename prevented me from cloning and running the project locally. I had to rename it to make the environment work. I included this fix in this PR because I couldn't verify the /health endpoint without it.

I am aware there is an existing discussion regarding this in Issue #84 